### PR TITLE
Add background music overlay

### DIFF
--- a/core/video_generator.py
+++ b/core/video_generator.py
@@ -199,7 +199,7 @@ class VideoGenerator:
             try:
                 bg_music = AudioFileClip(bg_path)
                 bg_music = afx.audio_loop(bg_music, duration=final.duration)
-                bg_music = bg_music.volumex(0.2)
+                bg_music = bg_music.volumex(0.05)
                 final_audio = CompositeAudioClip([final.audio, bg_music])
                 final = final.set_audio(final_audio)
             except Exception as e:


### PR DESCRIPTION
## Summary
- mix background music with narration when generating final video

## Testing
- `pytest -q`
- `python -m py_compile core/video_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_685046447f8483229828918569867633