### PR TITLE
Add script-based streaming endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,20 @@ The high-level flow of the application is illustrated in [docs/ARCHITECTURE.md](
    - Response: SSE stream with JSON messages for each task (0 to 5, plus "Completed").
    - Output: Video saved to `data/<request_id>/final_video.mp4`.
 
-2. **`/test-video` (GET)**:
+2. **`/stream-script` (POST)**:
+   - Streams the artifact generation steps using a pre-generated script JSON.
+   - Body: JSON payload with the same structure as the script output.
+   - Query parameters:
+     - `niche` (default: "news"): Pipeline variant to execute.
+   - Example:
+     ```bash
+     curl -X POST -H "Content-Type: application/json" \
+          -d @script.json http://localhost:28080/stream-script
+     ```
+   - Response: SSE stream with JSON messages for tasks 2a to 5.
+   - Output: Video saved to `data/<request_id>/final_video.mp4`.
+
+3. **`/test-video` (GET)**:
    - Generates a video from a sample JSON payload (`data/f851c750-b4a6-45fa-b23d-5c268e738e95/payload.json`).
    - Returns the video as a downloadable MP4 file.
    - Example:

--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 import asyncio
-from fastapi import FastAPI
+from fastapi import FastAPI, Body
 from fastapi.responses import StreamingResponse
 import os
 import uuid
@@ -275,6 +275,25 @@ async def pipeline_tasks(niche: str, country: str, category: str, query: str):
         yield message
     yield create_task_response(request_id, "Completed", "Success", f"Request ID: {request_id}")
 
+async def pipeline_from_result(niche: str, result_json: str):
+    """Run tasks using a pre-generated script JSON."""
+    handler = get_handler(niche, openai_client)
+    request_id = str(uuid.uuid4())
+    yield create_task_response(request_id, "0", "Success", f"Request ID: {request_id}")
+
+    # Use provided script JSON directly
+    handler.ai_response = result_json
+
+    async for message in serialize_script_response(handler, request_id):
+        yield message
+    async for message in convert_scripts_to_audio(handler, request_id):
+        yield message
+    async for message in generate_scene_images(handler, request_id):
+        yield message
+    async for message in stitch_video_from_scenes(handler, request_id):
+        yield message
+    yield create_task_response(request_id, "Completed", "Success", f"Request ID: {request_id}")
+
 @app.get("/stream")
 async def stream_endpoint(niche: str = "news", country: str = "us", category: str = "business", query: str = ""):
     """
@@ -306,6 +325,33 @@ async def stream_endpoint(niche: str = "news", country: str = "us", category: st
             "Cache-Control": "no-cache",
             "Connection": "keep-alive"
         }
+    )
+
+@app.post("/stream-script")
+async def stream_script_endpoint(
+    prompt_result: dict = Body(...),
+    niche: str = "news",
+):
+    """Stream pipeline using a pre-generated script JSON."""
+
+    result_json = json.dumps(prompt_result)
+
+    async def event_generator():
+        async for message in pipeline_from_result(niche, result_json):
+            yield f"data: {message}\n\n"
+            if '"Task":"Completed"' in message:
+                yield "data: {}\n\n"
+                break
+        return
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Content-Disposition": "inline",
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+        },
     )
 
 @app.get("/test-video")


### PR DESCRIPTION
## Summary
- add `pipeline_from_result` to run artifact generation from provided script JSON
- expose new `/stream-script` endpoint for SSE streaming
- document the endpoint in README

## Testing
- `python -m py_compile app.py utils.py core/video_service.py payload_parser.py niches/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855d810983c8322b5b827ba3f0eedeb